### PR TITLE
Fix theme toggle initialization

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -90,14 +90,17 @@ import Light_mode from "../assets/light_mode.svg"
   });
 </script>
 
-<script>
-  document.getElementById('theme-selector')?.addEventListener('click', () => {
-    if (localStorage.theme === 'dark') {
-      localStorage.theme = 'light';
-      document.documentElement.classList.remove('dark');
-    } else {
-      localStorage.theme = 'dark';
-      document.documentElement.classList.add('dark');
-    }
+<script is:inline>
+  document.addEventListener('DOMContentLoaded', () => {
+    const themeSelector = document.getElementById('theme-selector');
+    themeSelector?.addEventListener('click', () => {
+      if (localStorage.theme === 'dark') {
+        localStorage.theme = 'light';
+        document.documentElement.classList.remove('dark');
+      } else {
+        localStorage.theme = 'dark';
+        document.documentElement.classList.add('dark');
+      }
+    });
   });
 </script>


### PR DESCRIPTION
## Summary
- update the navbar theme toggle script to wait for DOMContentLoaded
- keep the existing light/dark toggling behavior while marking the script inline

## Testing
- npm run build
- Manual verification via dev server theme toggle


------
https://chatgpt.com/codex/tasks/task_e_68c93e703f3c8332a67d2d6588bf5982